### PR TITLE
Fix matches not saving

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -229,7 +229,7 @@ func GetSpecificTeamHandler(c *gin.Context) {
 	if teamID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing team ID"})
 	} else if _, err := strconv.Atoi(teamID); err != nil {
-		t, err = snc.TeamCalled(teamID, DB)
+		t, err = snc.FetchTeamNamed(teamID, DB)
 		if err != nil {
 			log.Println(err.Error())
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func databaseURL() string {
 		username := os.Getenv("SNC_USER")
 		password := os.Getenv("SNC_PW")
 		host := os.Getenv("SNC_HOST")
-		DBName := os.Getenv("SNC_DB")
+		DBName := "snc_gorm" //os.Getenv("SNC_DB")
 		URL = fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", username, password, host, DBName)
 	}
 	c := strings.LastIndex(URL, ":")
@@ -77,7 +77,7 @@ func main() {
 
 	defer DB.Close()
 
-	DB.AutoMigrate(&snc.Rink{}, &snc.Division{}, &snc.Team{}, &snc.Player{}, &snc.Match{}, &snc.Goal{}) //, &snc.Penalty{})
+	DB.AutoMigrate(&snc.Rink{}, &snc.Division{}, &snc.Team{}, &snc.Match{}) //&snc.Player{}, &snc.Match{}, &snc.Goal{}) //, &snc.Penalty{})
 	// todo find a way to do it such that the services aren't in the context
 	// todo rename updateX to be more in line with replaceX
 	// todo use PATCH to update parts of an entity and

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func databaseURL() string {
 		username := os.Getenv("SNC_USER")
 		password := os.Getenv("SNC_PW")
 		host := os.Getenv("SNC_HOST")
-		DBName := "snc_gorm" //os.Getenv("SNC_DB")
+		DBName := os.Getenv("SNC_DB")
 		URL = fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", username, password, host, DBName)
 	}
 	c := strings.LastIndex(URL, ":")

--- a/snc/match.go
+++ b/snc/match.go
@@ -29,19 +29,18 @@ type Match struct {
 	UpdatedAt time.Time  `json:"updatedAt"`
 	DeletedAt *time.Time `json:"-" sql:"index"`
 	// Datetime of the match start in UTC
-	Start      time.Time `json:"start" gorm:"not null;unique_index:idx_start_away_home"`
-	Season     int       `json:"season"`
-	Status     string    `json:"status"`
-	Division   Division  `json:"division"`
-	DivisionID uint      `json:"-"`
-	Away       Team      `json:"away"`
-	Home       Team      `json:"home"`
-	AwayID     uint      `json:"-" gorm:"not null;unique_index:idx_start_away_home"`
-	HomeID     uint      `json:"-" gorm:"not null;unique_index:idx_start_away_home"`
-	AwayScore  uint      `json:"awayScore"`
-	HomeScore  uint      `json:"homeScore"`
-	Rink       Rink      `json:"rink" gorm:"not null"`
-	RinkID     uint      `json:"-"`
+	Start        time.Time `json:"start" gorm:"not null;unique_index:idx_start_away_home"`
+	Season       int       `json:"season"`
+	Status       string    `json:"status"`
+	DivisionName string    `json:"divisionName"`
+	Away         Team      `json:"away" `
+	Home         Team      `json:"home"`
+	AwayID       uint      `json:"-" gorm:"not null;unique_index:idx_start_away_home"`
+	HomeID       uint      `json:"-" gorm:"not null;unique_index:idx_start_away_home"`
+	AwayScore    uint      `json:"awayScore"`
+	HomeScore    uint      `json:"homeScore"`
+	Rink         Rink      `json:"rink" gorm:"not null"`
+	RinkID       uint      `json:"-"`
 	//Goals	   []MatchGoal `json:"goals,omitempty"`
 }
 
@@ -52,8 +51,7 @@ func CreateMatch(m Match, DB *gorm.DB) error {
 
 func FetchMatch(id uint, DB *gorm.DB) (Match, error) {
 	m := Match{}
-	DB.Preload("Division").
-		Preload("Away").
+	DB.Preload("Away").
 		Preload("Home").
 		Where("ID = ? AND deleted_at IS NULL", id).First(&m)
 	return m, DB.Error
@@ -61,8 +59,7 @@ func FetchMatch(id uint, DB *gorm.DB) (Match, error) {
 
 func FetchMatches(DB *gorm.DB) ([]Match, error) {
 	m := make([]Match, 0)
-	DB.Preload("Division").
-		Preload("Away").
+	DB.Preload("Away").
 		Preload("Away.Division").
 		Preload("Home").
 		Preload("Home.Division").

--- a/snc/match.go
+++ b/snc/match.go
@@ -45,37 +45,37 @@ type Match struct {
 }
 
 func CreateMatch(m Match, DB *gorm.DB) error {
-	DB.Create(&m)
-	return DB.Error
+	res := DB.Create(&m)
+	return res.Error
 }
 
 func FetchMatch(id uint, DB *gorm.DB) (Match, error) {
 	m := Match{}
-	DB.Preload("Away").
+	res := DB.Preload("Away").
 		Preload("Home").
 		Where("ID = ? AND deleted_at IS NULL", id).First(&m)
-	return m, DB.Error
+	return m, res.Error
 }
 
 func FetchMatches(DB *gorm.DB) ([]Match, error) {
 	m := make([]Match, 0)
-	DB.Preload("Away").
+	res := DB.Preload("Away").
 		Preload("Away.Division").
 		Preload("Home").
 		Preload("Home.Division").
 		Preload("Rink").Where("deleted_at IS NULL").Find(&m)
-	return m, DB.Error
+	return m, res.Error
 }
 
 func UpdateMatch(m Match, DB *gorm.DB) error {
-	DB.Where("deleted_at IS NULL").Save(&m)
-	return DB.Error
+	res := DB.Where("deleted_at IS NULL").Save(&m)
+	return res.Error
 }
 
 func DeleteMatch(id uint, DB *gorm.DB) error {
 	var m Match
-	DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&m)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&m)
+	return res.Error
 }
 
 //-----------------------------------------------//
@@ -95,34 +95,33 @@ type Goal struct {
 }
 
 func CreateGoal(g Goal, DB *gorm.DB) error {
-	DB.Create(&g)
-	return DB.Error
+	res := DB.Create(&g)
+	return res.Error
 }
 
 func FetchGoal(id uint, DB *gorm.DB) (Goal, error) {
 	g := Goal{}
-	DB.
-		Preload("Team").
+	res := DB.Preload("Team").
 		Preload("Scorer").
 		Where("ID = ? AND deleted_at IS NULL", id).First(&g)
-	return g, DB.Error
+	return g, res.Error
 }
 
 func FetchGoals(DB *gorm.DB) ([]Goal, error) {
 	m := make([]Goal, 0)
-	DB.Where("deleted_at IS NULL").Find(&m)
-	return m, DB.Error
+	res := DB.Where("deleted_at IS NULL").Find(&m)
+	return m, res.Error
 }
 
 func UpdateGoal(g Goal, DB *gorm.DB) error {
-	DB.Where("deleted_at IS NULL").Save(&g)
-	return DB.Error
+	res := DB.Where("deleted_at IS NULL").Save(&g)
+	return res.Error
 }
 
 func DeleteGoal(id uint, DB *gorm.DB) error {
 	var g Goal
-	DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&g)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&g)
+	return res.Error
 }
 
 //type MatchGoal struct {

--- a/snc/rink.go
+++ b/snc/rink.go
@@ -19,29 +19,39 @@ type Rink struct {
 }
 
 func CreateRink(r Rink, DB *gorm.DB) error {
-	DB.Create(&r)
-	return DB.Error
+	rink, _ := FetchRinkNamed(r.Name, DB)
+	if rink.ID != 0 {
+		return UpdateRink(r, DB)
+	}
+	res := DB.Create(&r)
+	return res.Error
 }
 
 func FetchRink(id uint, DB *gorm.DB) (Rink, error) {
 	var r Rink
-	DB.Where("ID = ? AND deleted_at IS NULL", id).First(&r)
-	return r, DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).First(&r)
+	return r, res.Error
+}
+
+func FetchRinkNamed(name string, DB *gorm.DB) (Rink, error) {
+	var r Rink
+	res := DB.Where("Name = ? AND deleted_at IS NULL", name).First(&r)
+	return r, res.Error
 }
 
 func FetchRinks(DB *gorm.DB) ([]Rink, error) {
 	r := make([]Rink, 0)
-	DB.Where("deleted_at IS NULL").Find(&r)
-	return r, DB.Error
+	res := DB.Where("deleted_at IS NULL").Find(&r)
+	return r, res.Error
 }
 
 func UpdateRink(r Rink, DB *gorm.DB) error {
-	DB.Where("ID = ? AND deleted_at IS NULL", r.ID).Save(&r)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", r.ID).Save(&r)
+	return res.Error
 }
 
 func DeleteRink(id int, DB *gorm.DB) error {
 	var r Rink
-	DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&r)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&r)
+	return res.Error
 }

--- a/snc/rink.go
+++ b/snc/rink.go
@@ -15,12 +15,13 @@ type Rink struct {
 	CreatedAt time.Time  `json:"createdAt"`
 	UpdatedAt time.Time  `json:"updatedAt"`
 	DeletedAt *time.Time `json:"-" sql:"index"`
-	Name      string     `json:"name" gorm:"not null;unique_index"`
+	Name      string     `json:"name" gorm:"not null;unique_index;primary_key"`
 }
 
 func CreateRink(r Rink, DB *gorm.DB) error {
 	rink, _ := FetchRinkNamed(r.Name, DB)
 	if rink.ID != 0 {
+		r.ID = rink.ID
 		return UpdateRink(r, DB)
 	}
 	res := DB.Create(&r)
@@ -29,7 +30,7 @@ func CreateRink(r Rink, DB *gorm.DB) error {
 
 func FetchRink(id uint, DB *gorm.DB) (Rink, error) {
 	var r Rink
-	res := DB.Where("ID = ? AND deleted_at IS NULL", id).First(&r)
+	res := DB.Where("id = ? AND deleted_at IS NULL", id).First(&r)
 	return r, res.Error
 }
 
@@ -46,12 +47,12 @@ func FetchRinks(DB *gorm.DB) ([]Rink, error) {
 }
 
 func UpdateRink(r Rink, DB *gorm.DB) error {
-	res := DB.Where("ID = ? AND deleted_at IS NULL", r.ID).Save(&r)
+	res := DB.Where("id = ? AND deleted_at IS NULL", r.ID).Save(&r)
 	return res.Error
 }
 
 func DeleteRink(id int, DB *gorm.DB) error {
 	var r Rink
-	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&r)
+	res := DB.Where("id = ? AND deleted_at IS NULL", id).Delete(&r)
 	return res.Error
 }

--- a/snc/team.go
+++ b/snc/team.go
@@ -6,7 +6,6 @@ import (
 	"time"
 )
 
-// todo use deleted at fields
 //--------------------------------------------------------------------------------------------------------------------//
 // Team
 //--------------------------------------------------------------------------------------------------------------------//
@@ -15,11 +14,16 @@ type Team struct {
 	CreatedAt    time.Time  `json:"createdAt"`
 	UpdatedAt    time.Time  `json:"updatedAt"`
 	DeletedAt    *time.Time `json:"-" sql:"index"`
-	Name         string     `json:"name" gorm:"not null;unique_index"`
+	Name         string     `json:"name" gorm:"not null;unique_index;primary_key"`
 	DivisionName string     `json:"divisionName"`
 }
 
 func CreateTeam(t Team, DB *gorm.DB) error {
+	team, _ := FetchTeamNamed(t.Name, DB)
+	if team.ID != 0 {
+		t.ID = team.ID
+		return UpdateTeam(t, DB)
+	}
 	res := DB.Create(&t)
 	return res.Error
 }
@@ -37,20 +41,20 @@ func FetchTeams(DB *gorm.DB) ([]Team, error) {
 	return teams, res.Error
 }
 
-func TeamCalled(name string, DB *gorm.DB) (Team, error) {
+func FetchTeamNamed(name string, DB *gorm.DB) (Team, error) {
 	var team Team
 	res := DB.Where("name = ? AND deleted_at IS NULL", name).First(&team)
 	return team, res.Error
 }
 
 func UpdateTeam(t Team, DB *gorm.DB) error {
-	res := DB.Where("ID = ? AND deleted_at IS NULL", t.ID).Save(&t)
+	res := DB.Where("id = ? AND deleted_at IS NULL", t.ID).Save(&t)
 	return res.Error
 }
 
 func DeleteTeam(id uint, DB *gorm.DB) error {
 	var team Team
-	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&team)
+	res := DB.Where("id = ? AND deleted_at IS NULL", id).Delete(&team)
 	return res.Error
 }
 
@@ -62,7 +66,7 @@ type Division struct {
 	CreatedAt time.Time  `json:"createdAt"`
 	UpdatedAt time.Time  `json:"updatedAt"`
 	DeletedAt *time.Time `json:"-" sql:"index"`
-	Name      string     `json:"name" gorm:"not null;unique_index"`
+	Name      string     `json:"name" gorm:"not null;unique_index;primary_key"`
 	Teams     []Team     `json:"teams" gorm:"ForeignKey:DivisionName;AssociationForeignKey:Name"`
 }
 
@@ -84,13 +88,13 @@ func FetchDivisions(DB *gorm.DB) ([]Division, error) {
 }
 
 func UpdateDivision(d Division, DB *gorm.DB) error {
-	res := DB.Where("ID = ? AND deleted_at IS NULL", d.ID).Save(&d)
+	res := DB.Where("id = ? AND deleted_at IS NULL", d.ID).Save(&d)
 	return res.Error
 }
 
 func DeleteDivision(id int, DB *gorm.DB) error {
 	var div Division
-	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&div)
+	res := DB.Where("id = ? AND deleted_at IS NULL", id).Delete(&div)
 	return res.Error
 }
 

--- a/snc/team.go
+++ b/snc/team.go
@@ -20,38 +20,38 @@ type Team struct {
 }
 
 func CreateTeam(t Team, DB *gorm.DB) error {
-	DB.Create(&t)
-	return DB.Error
+	res := DB.Create(&t)
+	return res.Error
 }
 
 func FetchTeam(id uint, DB *gorm.DB) (Team, error) {
 	fmt.Println("Fetching team")
 	var team Team
-	DB.Where("deleted_at IS NULL").First(&team, id)
-	return team, DB.Error
+	res := DB.Where("deleted_at IS NULL").First(&team, id)
+	return team, res.Error
 }
 
 func FetchTeams(DB *gorm.DB) ([]Team, error) {
 	teams := make([]Team, 0)
-	DB = DB.Where("deleted_at IS NULL").Find(&teams)
-	return teams, DB.Error
+	res := DB.Where("deleted_at IS NULL").Find(&teams)
+	return teams, res.Error
 }
 
 func TeamCalled(name string, DB *gorm.DB) (Team, error) {
 	var team Team
-	DB.Where("name = ? AND deleted_at IS NULL", name).First(&team)
-	return team, DB.Error
+	res := DB.Where("name = ? AND deleted_at IS NULL", name).First(&team)
+	return team, res.Error
 }
 
 func UpdateTeam(t Team, DB *gorm.DB) error {
-	DB.Where("ID = ? AND deleted_at IS NULL", t.ID).Save(&t)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", t.ID).Save(&t)
+	return res.Error
 }
 
 func DeleteTeam(id uint, DB *gorm.DB) error {
 	var team Team
-	DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&team)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&team)
+	return res.Error
 }
 
 //--------------------------------------------------------------------------------------------------------------------//
@@ -67,31 +67,31 @@ type Division struct {
 }
 
 func CreateDivision(d Division, DB *gorm.DB) error {
-	DB.Create(&d)
-	return DB.Error
+	res := DB.Create(&d)
+	return res.Error
 }
 
 func FetchDivision(id uint, DB *gorm.DB) (Division, error) {
 	var d Division
-	DB.Preload("Teams").Where("ID = ? AND deleted_at IS NULL", id).First(&d)
-	return d, DB.Error
+	res := DB.Preload("Teams").Where("ID = ? AND deleted_at IS NULL", id).First(&d)
+	return d, res.Error
 }
 
 func FetchDivisions(DB *gorm.DB) ([]Division, error) {
 	d := make([]Division, 0)
-	DB.Preload("Teams").Where("deleted_at IS NULL").Find(&d)
-	return d, DB.Error
+	res := DB.Preload("Teams").Where("deleted_at IS NULL").Find(&d)
+	return d, res.Error
 }
 
 func UpdateDivision(d Division, DB *gorm.DB) error {
-	DB.Where("ID = ? AND deleted_at IS NULL", d.ID).Save(&d)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", d.ID).Save(&d)
+	return res.Error
 }
 
 func DeleteDivision(id int, DB *gorm.DB) error {
 	var div Division
-	DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&div)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&div)
+	return res.Error
 }
 
 //--------------------------------------------------------------------------------------------------------------------//
@@ -105,29 +105,29 @@ type Player struct {
 }
 
 func CreatePlayer(p Player, DB *gorm.DB) error {
-	DB.Create(&p)
-	return DB.Error
+	res := DB.Create(&p)
+	return res.Error
 }
 
 func FetchPlayer(id uint, DB *gorm.DB) (Player, error) {
 	var p Player
-	DB.Where("ID = ? AND deleted_at IS NULL", id).First(&p)
-	return p, DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).First(&p)
+	return p, res.Error
 }
 
 func FetchPlayers(DB *gorm.DB) ([]Player, error) {
 	p := make([]Player, 0)
-	DB.Where("deleted_at IS NULL").Find(&p)
-	return p, DB.Error
+	res := DB.Where("deleted_at IS NULL").Find(&p)
+	return p, res.Error
 }
 
 func UpdatePlayer(p Player, DB *gorm.DB) error {
-	DB.Where("ID = ? AND deleted_at IS NULL", p.ID).Save(&p)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", p.ID).Save(&p)
+	return res.Error
 }
 
 func DeletePlayer(id int, DB *gorm.DB) error {
 	var p Player
-	DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&p)
-	return DB.Error
+	res := DB.Where("ID = ? AND deleted_at IS NULL", id).Delete(&p)
+	return res.Error
 }


### PR DESCRIPTION
Also
- Changed match divisions to be names instead of structs
- Made ID in the Where functions lower case to match DB columns
- Bubbled up the DB errors instead of squashing them
- Include name as primary key for some tables because it is just as telling as ID and is known when submitting (I may remove this though because I haven't verified if it is doing anything now I have a hack in place to save matches, I suspect it is not).

Fixes #37, and #26